### PR TITLE
0.3 - Ammo, metal, charge meter, and etc management

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ It is currently missing some planned features, such as ammo and charge meter man
 	- 2: Keep the ratio of health to max health the same
 	- Any other value: Full heal
 - `ccotg_health_max_overheal` (1.5) - Max amount of overheal (multiplier of max health) that players are allowed to keep upon changing classes.
+- `ccotg_ammo_management` (1) - Saves ammo, charge meters, heads and similar things separately for each class until death.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Change Class on the Go
 Scuffed pseudo-gamemode that allows everyone to change classes at will, anywhere.
 
-It is currently missing some planned features, such as ammo and charge meter management.
-
 ## Dependencies
 - SourceMod 1.11
 - [SlidyBat's SendProxy Manager extension fork](https://github.com/SlidyBat/sendproxy)

--- a/gamedata/ccotg.txt
+++ b/gamedata/ccotg.txt
@@ -10,11 +10,35 @@
 				"linux"		"@_ZN9CTFPlayer9AddObjectEP11CBaseObject"
 				"windows"	"\x55\x8B\xEC\x53\x56\x57\x8B\x7D\x08\x8B\xD9\x85\xFF\x74\x2A\x8B\x07\x8B\xCF\xFF\x50\x08\x8B\xCF"
 			}
+			
 			"CTFPlayer::RemoveObject"
 			{
 				"library"	"server"
 				"linux"		"@_ZN9CTFPlayer12RemoveObjectEP11CBaseObject"
 				"windows"	"\x55\x8B\xEC\x8B\xD1\x56\x8B\xB2\x8C\x21\x00\x00"
+			}
+			
+			"CTFPlayer::GetEquippedWearableForLoadoutSlot"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9CTFPlayer33GetEquippedWearableForLoadoutSlotEi"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x2A\x8B\xC1\x53\x56\x33\xF6\x89\x45\xF8\x8B\x88\x2A\x2A\x2A\x2A\x57\x89\x4D\xFC"
+			}
+			
+			"CTFPlayer::GetMaxAmmo"
+			{
+				"library"	"server"
+				"linux"		"@_ZN9CTFPlayer10GetMaxAmmoEii"
+				"windows"	"\x55\x8B\xEC\x8B\x45\x0C\x56\x57\x8B\xF9\x83\xF8\xFF\x75\x2A\xFF\xB7\x2A\x2A\x2A\x2A\xEB\x01\x50\xE8"
+			}
+		}
+		
+		"Offsets"
+		{
+			"CTFWeaponBase::GetMaxClip1"
+			{
+				"linux"		"327"
+				"windows"	"321"
 			}
 		}
 	}

--- a/scripting/ccotg.sp
+++ b/scripting/ccotg.sp
@@ -31,6 +31,19 @@ char g_sClassNames[view_as<int>(TFClass_Engineer) + 1][] = {
 	"engineer"
 };
 
+enum
+{
+	TF_AMMO_DUMMY = 0,
+	TF_AMMO_PRIMARY,	//General primary weapon ammo
+	TF_AMMO_SECONDARY,	//General secondary weapon ammo
+	TF_AMMO_METAL,		//Engineer's metal
+	TF_AMMO_GRENADES1,	//Weapon misc ammo 1
+	TF_AMMO_GRENADES2,	//Weapon misc ammo 2
+	TF_AMMO_GRENADES3,
+	
+	TF_AMMO_COUNT
+}
+
 ConVar g_cvEnabled;
 ConVar g_cvCooldown;
 ConVar g_cvOnlyAllowTeam;
@@ -77,6 +90,11 @@ public void OnMapStart()
 public void OnClientPutInServer(int iClient)
 {
 	Player(iClient).Reset();
+}
+
+public void OnClientDisconnect(int iClient)
+{
+	Player(iClient).Destroy();
 }
 
 public void OnPluginEnd()
@@ -149,6 +167,12 @@ public void Disable()
 	SendProxy_UnhookGameRules("m_iRoundState", SendProxy_ArenaRoundState);
 	UnhookEntityOutput("tf_logic_arena", "OnCapEnabled", EntityOutput_OnArenaCapEnabled);
 	
+	// Treat in-game clients as if they're disconnecting (frees up memory space)
+	for (int iClient = 1; iClient <= MaxClients; iClient++)
+	{
+		if (IsClientInGame(iClient))
+			OnClientDisconnect(iClient);
+	}
 	int iEntity = MaxClients + 1;
 	
 	// Unhook spawn rooms

--- a/scripting/ccotg.sp
+++ b/scripting/ccotg.sp
@@ -50,6 +50,7 @@ ConVar g_cvOnlyAllowTeam;
 ConVar g_cvKeepBuildings;
 ConVar g_cvHealthMode;
 ConVar g_cvHealthMaxOverheal;
+ConVar g_cvAmmoManagement;
 ConVar g_cvPreventSwitchingDuringBadStates;
 ConVar g_cvMessWithArenaRoundStates;
 

--- a/scripting/ccotg.sp
+++ b/scripting/ccotg.sp
@@ -9,7 +9,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION		"0.2"
+#define PLUGIN_VERSION		"0.3"
 
 bool g_bArenaMode;
 

--- a/scripting/ccotg.sp
+++ b/scripting/ccotg.sp
@@ -66,9 +66,9 @@ public Plugin myinfo =
 {
 	name = "Change Class on the Go",
 	author = "wo",
-	description = "local demoknight holds m2 and can not be stopped",
+	description = "Allows players to change classes and not die out of spawn.",
 	version = PLUGIN_VERSION,
-	url = "https://steamcommunity.com/id/mmmwo/"
+	url = "https://github.com/woisalreadytaken/ChangeClassOnTheGo"
 }
 
 public void OnPluginStart()

--- a/scripting/ccotg/console.sp
+++ b/scripting/ccotg/console.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 void Console_Init()
 {
 	AddCommandListener(CommandListener_ChangeClass, "dropitem");

--- a/scripting/ccotg/convars.sp
+++ b/scripting/ccotg/convars.sp
@@ -8,6 +8,7 @@ void ConVar_Init()
 	g_cvKeepBuildings = CreateConVar("ccotg_keep_buildings", "1", "Lets buildings stay on the map if a player switches from Engineer. Disabling makes them get destroyed instead.");
 	g_cvHealthMode = CreateConVar("ccotg_health_mode", "1", "How should health be handled upon changing classes?\n1: Don't change health\n2: Keep the ratio of health to max health the same\nAny other value: Full heal");
 	g_cvHealthMaxOverheal = CreateConVar("ccotg_health_max_overheal", "1.5", "Max amount of overheal (multiplier of max health) that players are allowed to keep upon changing classes.");
+	g_cvAmmoManagement = CreateConVar("ccotg_ammo_management", "1", "Saves ammo, charge meters, heads and similar things separately for each class until death.");
 	g_cvPreventSwitchingDuringBadStates = CreateConVar("ccotg_prevent_switching_during_bad_states", "1", "Lazy temporary beta convar - disallows switching classes if are doing following: Jetpacking (to prevent a persistent looping sound bug) and hauling a building (does some bad animation stuff)");
 	g_cvMessWithArenaRoundStates = CreateConVar("ccotg_arena_change_round_states", "1", "Pretend to change the round state in arena mode so players can use the default 'changeclass' key mid round. Visually, slightly breaks the central Control Point! Disabling will let players change classes with their 'dropitem' key as a fallback instead.");
 	g_cvMessWithArenaRoundStates.AddChangeHook(ConVar_MessWithArenaRoundStatesChanged);

--- a/scripting/ccotg/convars.sp
+++ b/scripting/ccotg/convars.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 void ConVar_Init()
 {
 	g_cvEnabled = CreateConVar("ccotg_enabled", "1", "Is 'Change Class on the Go' enabled?", _, true, 0.0, true, 1.0);

--- a/scripting/ccotg/events.sp
+++ b/scripting/ccotg/events.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 void Event_Init()
 {
 	HookEvent("player_spawn", Event_PlayerSpawn);
@@ -56,7 +59,7 @@ public Action Event_RoundStart(Event event, const char[] sName, bool bDontBroadc
 			if (!Player(iClient).bHasChangedClass && Player(iClient).CanTeamChangeClass())
 			{
 				CPrintToChat(iClient, "%t", "ChangeClass_Arena_Hint");
-				PrintKeyHintText(iClient, "%t", "ChangeClass_Arena_Controls")
+				PrintKeyHintText(iClient, "%t", "ChangeClass_Arena_Controls");
 			}
 		}
 	}

--- a/scripting/ccotg/events.sp
+++ b/scripting/ccotg/events.sp
@@ -19,6 +19,9 @@ public Action Event_PlayerSpawn(Event event, const char[] sName, bool bDontBroad
 	// Reset the player's buffered class
 	Player(iClient).nBufferedClass = TFClass_Unknown;
 	
+	// Reset the player's class data
+	Player(iClient).ResetAllClassData();
+	
 	// If the player hasn't switched classes yet, nag them on each spawn until they do
 	if (!Player(iClient).bHasChangedClass && Player(iClient).CanTeamChangeClass())
 		PrintCenterText(iClient, "%t", "ChangeClass_Main_Hint");

--- a/scripting/ccotg/methodmaps.sp
+++ b/scripting/ccotg/methodmaps.sp
@@ -193,6 +193,9 @@ methodmap Player
 	
 	public void StoreClassData(TFClassType nClass)
 	{
+		if (!g_cvAmmoManagement.BoolValue)
+			return;
+		
 		ClassData data;
 		data.nClass = nClass;
 		
@@ -309,6 +312,9 @@ methodmap Player
 	
 	public void ApplyClassData(TFClassType nClass)
 	{
+		if (!g_cvAmmoManagement.BoolValue)
+			return;
+		
 		int iValue = g_aClassData[this.iClient].FindValue(nClass, ClassData::nClass);
 		
 		// Haven't played this class yet, set things that would normally transfer over to 0

--- a/scripting/ccotg/methodmaps.sp
+++ b/scripting/ccotg/methodmaps.sp
@@ -27,7 +27,6 @@ enum struct ClassData
 	bool bRageDraining;
 	bool bUbercharging;
 	
-	int iSpell;
 	float flLastSwitch;
 }
 
@@ -91,6 +90,18 @@ methodmap Player
 		public set(TFClassType nBufferedClass)
 		{
 			g_nBufferedClass[this.iClient] = nBufferedClass;
+		}
+	}
+	
+	property ArrayList aClassData
+	{
+		public get()
+		{
+			return g_aClassData[this.iClient];
+		}
+		public set(ArrayList aClassData)
+		{
+			g_aClassData[this.iClient] = aClassData;
 		}
 	}
 	

--- a/scripting/ccotg/methodmaps.sp
+++ b/scripting/ccotg/methodmaps.sp
@@ -2,6 +2,31 @@ static float g_flLastClassChange[MAXPLAYERS + 1];
 static bool g_bHasChangedClass[MAXPLAYERS + 1];
 static bool g_bIsInRespawnRoom[MAXPLAYERS + 1];
 static TFClassType g_nBufferedClass[MAXPLAYERS + 1];
+static ArrayList g_aClassData[MAXPLAYERS + 1];
+
+enum struct ClassData
+{
+	TFClassType nClass;
+	
+	int iClip[3];
+	int iAmmo[TF_AMMO_COUNT];
+	float flWeaponChargeMeter[3];
+	float flWeaponChargeTime[3];
+	
+	int iMetal;
+	int iHeads;
+	int iRevengeCrits;
+	float flChargeMeter;
+	float flRage;
+	float flHype;
+	float flCloak;
+	
+	bool bRageDraining;
+	bool bUbercharging;
+	
+	int iSpell;
+	float flLastSwitch;
+}
 
 methodmap Player
 {
@@ -72,6 +97,8 @@ methodmap Player
 		this.bHasChangedClass = false;
 		this.bIsInRespawnRoom = false;
 		this.nBufferedClass = TFClass_Unknown;
+		
+		this.ResetAllClassData();
 	}
 	
 	public void SetClass(TFClassType nClass)
@@ -108,9 +135,15 @@ methodmap Player
 		int iOldHealth = GetEntProp(this.iClient, Prop_Send, "m_iHealth");
 		int iOldMaxHealth = SDKCall_GetMaxHealth(this.iClient);
 		
+		// Store ammo, charge meters and the like
+		this.StoreClassData(nCurrentClass);
+		
 		// Change classes!
 		TF2_SetPlayerClass(this.iClient, nClass, false, true);
 		TF2_RegeneratePlayer(this.iClient);
+		
+		// Retrieve ammo, charge meters and the like if we've already played the class we're switching to before
+		this.ApplyClassData(nClass);
 		
 		// If switching back to engineer, check if there are any owned-but-not-really buildings and attach them back to the player
 		if (nClass == TFClass_Engineer && g_cvKeepBuildings.BoolValue)
@@ -156,6 +189,263 @@ methodmap Player
 		// Update properties
 		this.flLastClassChange = GetGameTime();
 		this.bHasChangedClass = true;
+	}
+	
+	public void StoreClassData(TFClassType nClass)
+	{
+		ClassData data;
+		data.nClass = nClass;
+		
+		// Get client ent props
+		
+		// Class-specific
+		switch(nClass)
+		{
+			case TFClass_Scout: data.flHype = GetEntPropFloat(this.iClient, Prop_Send, "m_flHypeMeter");
+			case TFClass_DemoMan: data.flChargeMeter = GetEntPropFloat(this.iClient, Prop_Send, "m_flChargeMeter");
+			case TFClass_Engineer: data.iMetal = GetEntProp(this.iClient, Prop_Send, "m_iAmmo", _, TF_AMMO_METAL);
+			case TFClass_Spy: data.flCloak = GetEntPropFloat(this.iClient, Prop_Send, "m_flCloakMeter");
+		}
+		
+		// Multiple classes use these
+		data.iHeads = GetEntProp(this.iClient, Prop_Send, "m_iDecapitations");
+		data.iRevengeCrits = GetEntProp(this.iClient, Prop_Send, "m_iRevengeCrits");
+		data.flRage = GetEntPropFloat(this.iClient, Prop_Send, "m_flRageMeter");
+		data.bRageDraining = view_as<bool>(GetEntProp(this.iClient, Prop_Send, "m_bRageDraining"));
+		
+		data.flLastSwitch = GetGameTime();
+		
+		// Deal with weapons
+		for (int i = TFWeaponSlot_Primary; i <= TFWeaponSlot_Melee; i++)
+		{
+			int iWeapon = TF2_GetItemInSlot(this.iClient, i);
+			
+			if (iWeapon <= MaxClients)
+				continue;
+			
+			// Store weapon clip and ammo
+			if (HasEntProp(iWeapon, Prop_Send, "m_iClip1"))
+				data.iClip[i] = GetEntProp(iWeapon, Prop_Send, "m_iClip1");
+			
+			if (HasEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType"))
+			{
+				int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
+				if (iAmmoType > -1)
+					data.iAmmo[iAmmoType] = GetEntProp(this.iClient, Prop_Send, "m_iAmmo", _, iAmmoType);
+			}
+			
+			char sClassname[32];
+			GetEntityClassname(iWeapon, sClassname, sizeof(sClassname));
+			
+			// Store weapon-specific charge meters
+			switch(i)
+			{
+				case TFWeaponSlot_Primary:
+				{
+					if (StrEqual(sClassname, "tf_weapon_particle_cannon") || StrEqual(sClassname, "tf_weapon_drg_pomson"))
+					{
+						data.flWeaponChargeMeter[i] = GetEntPropFloat(iWeapon, Prop_Send, "m_flEnergy");
+					}
+					else
+					{
+						data.flWeaponChargeMeter[i] = GetEntPropFloat(this.iClient, Prop_Send, "m_flItemChargeMeter", i);
+					}
+				}
+				
+				case TFWeaponSlot_Secondary:
+				{
+					if (StrEqual(sClassname, "tf_weapon_medigun"))
+					{
+						data.flWeaponChargeMeter[i] = GetEntPropFloat(iWeapon, Prop_Send, "m_flChargeLevel");
+						data.bUbercharging = view_as<bool>(GetEntProp(iWeapon, Prop_Send, "m_bChargeRelease"));
+					}
+					else if (StrEqual(sClassname, "tf_weapon_raygun"))
+					{
+						data.flWeaponChargeMeter[i] = GetEntPropFloat(iWeapon, Prop_Send, "m_flEnergy");
+					}
+					else if (StrEqual(sClassname, "tf_weapon_charged_smg"))
+					{
+						data.flWeaponChargeMeter[i] = GetEntPropFloat(iWeapon, Prop_Send, "m_flMinicritCharge");
+					}
+					else if (StrEqual(sClassname, "tf_weapon_rocketpack") || StrEqual(sClassname, "tf_weapon_jar_gas") || StrEqual(sClassname, "tf_weapon_lunchbox") || StrEqual(sClassname, "tf_wearable_razorback"))
+					{
+						data.flWeaponChargeMeter[i] = GetEntPropFloat(this.iClient, Prop_Send, "m_flItemChargeMeter", i);
+					}
+					else if (HasEntProp(iWeapon, Prop_Send, "m_flEffectBarRegenTime"))
+					{
+						data.flWeaponChargeTime[i] = GetEntPropFloat(iWeapon, Prop_Send, "m_flEffectBarRegenTime");
+					}
+				}
+				
+				case TFWeaponSlot_Melee:
+				{
+					if (StrEqual(sClassname, "tf_weapon_knife"))
+					{
+						data.flWeaponChargeTime[i] = GetEntPropFloat(iWeapon, Prop_Send, "m_flKnifeMeltTimestamp");
+					}
+					else if (HasEntProp(iWeapon, Prop_Send, "m_flEffectBarRegenTime"))
+					{
+						data.flWeaponChargeTime[i] = GetEntPropFloat(iWeapon, Prop_Send, "m_flEffectBarRegenTime");
+					}
+					else
+					{
+						data.flWeaponChargeMeter[i] = GetEntPropFloat(this.iClient, Prop_Send, "m_flItemChargeMeter", i);
+					}
+				}
+			}
+		}
+		
+		// If we haven't already played this class, add data for it, and if we have, replace
+		int iValue = g_aClassData[this.iClient].FindValue(nClass, ClassData::nClass);
+		if (iValue == -1)
+		{
+			g_aClassData[this.iClient].PushArray(data);
+		}
+		else
+		{
+			g_aClassData[this.iClient].SetArray(iValue, data);
+		}
+	}
+	
+	public void ApplyClassData(TFClassType nClass)
+	{
+		int iValue = g_aClassData[this.iClient].FindValue(nClass, ClassData::nClass);
+		
+		// Haven't played this class yet, set things that would normally transfer over to 0
+		if (iValue == -1)
+		{
+			SetEntProp(this.iClient, Prop_Send, "m_iDecapitations", 0);
+			SetEntProp(this.iClient, Prop_Send, "m_iRevengeCrits", 0);
+			SetEntPropFloat(this.iClient, Prop_Send, "m_flRageMeter", 0.0);
+			SetEntProp(this.iClient, Prop_Send, "m_bRageDraining", false);
+			
+			return;
+		}
+		
+		ClassData data;
+		g_aClassData[this.iClient].GetArray(iValue, data);
+		
+		// Set client ent props
+		SetEntProp(this.iClient, Prop_Send, "m_iAmmo", data.iMetal, _, TF_AMMO_METAL);
+		SetEntProp(this.iClient, Prop_Send, "m_iDecapitations", data.iHeads);
+		SetEntProp(this.iClient, Prop_Send, "m_iRevengeCrits", data.iRevengeCrits);
+		SetEntPropFloat(this.iClient, Prop_Send, "m_flChargeMeter", data.flChargeMeter);
+		SetEntPropFloat(this.iClient, Prop_Send, "m_flRageMeter", data.flRage);
+		SetEntPropFloat(this.iClient, Prop_Send, "m_flHypeMeter", data.flHype);
+		SetEntPropFloat(this.iClient, Prop_Send, "m_flCloakMeter", data.flCloak);
+		SetEntProp(this.iClient, Prop_Send, "m_bRageDraining", data.bRageDraining);
+		
+		// Deal with weapons
+		for (int i = TFWeaponSlot_Primary; i <= TFWeaponSlot_Melee; i++)
+		{
+			int iWeapon = TF2_GetItemInSlot(this.iClient, i);
+			
+			if (iWeapon <= MaxClients)
+				continue;
+			
+			// Set clip size and ammo
+			if (HasEntProp(iWeapon, Prop_Send, "m_iClip1"))
+			{
+				int iExpectedClip = Min(data.iClip[i], SDKCall_GetMaxClip(iWeapon));
+				SetEntProp(iWeapon, Prop_Send, "m_iClip1", iExpectedClip);
+			}
+			
+			if (HasEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType"))
+			{
+				int iAmmoType = GetEntProp(iWeapon, Prop_Send, "m_iPrimaryAmmoType");
+				if (iAmmoType > -1)
+				{
+					int iExpectedAmmo = Min(data.iAmmo[iAmmoType], SDKCall_GetMaxAmmo(this.iClient, iAmmoType));
+					SetEntProp(this.iClient, Prop_Send, "m_iAmmo", iExpectedAmmo, _, iAmmoType);
+				}
+			}
+			
+			char sClassname[32];
+			GetEntityClassname(iWeapon, sClassname, sizeof(sClassname));
+			
+			// Apply weapon-specific charge meters
+			switch(i)
+			{
+				case TFWeaponSlot_Primary:
+				{
+					if (StrEqual(sClassname, "tf_weapon_particle_cannon") || StrEqual(sClassname, "tf_weapon_drg_pomson"))
+					{
+						SetEntPropFloat(iWeapon, Prop_Send, "m_flEnergy", data.flWeaponChargeMeter[i]);
+					}
+					else
+					{
+						if (data.flWeaponChargeMeter[i] > 0.0)
+							SetEntPropFloat(this.iClient, Prop_Send, "m_flItemChargeMeter", data.flWeaponChargeMeter[i], i);
+					}
+				}
+				
+				case TFWeaponSlot_Secondary:
+				{
+					if (StrEqual(sClassname, "tf_weapon_medigun"))
+					{
+						SetEntPropFloat(iWeapon, Prop_Send, "m_flChargeLevel", data.flWeaponChargeMeter[i]);
+						SetEntProp(iWeapon, Prop_Send, "m_bChargeRelease", data.bUbercharging);
+					}
+					else if (StrEqual(sClassname, "tf_weapon_raygun"))
+					{
+						SetEntPropFloat(iWeapon, Prop_Send, "m_flEnergy", data.flWeaponChargeMeter[i]);
+					}
+					else if (StrEqual(sClassname, "tf_weapon_charged_smg"))
+					{
+						SetEntPropFloat(iWeapon, Prop_Send, "m_flMinicritCharge", data.flWeaponChargeMeter[i]);
+					}
+					else if (StrEqual(sClassname, "tf_weapon_lunchbox_drink") || StrEqual(sClassname, "tf_weapon_jar") || StrEqual(sClassname, "tf_weapon_jar_milk") || StrEqual(sClassname, "tf_weapon_cleaver"))
+					{
+						// This apparently refreshes ammo on some weapons that don't use it (which is why the classnames are all hardcoded). cute
+						SetEntPropFloat(iWeapon, Prop_Send, "m_flEffectBarRegenTime", (data.flWeaponChargeTime[i] + GetGameTime()) - data.flLastSwitch);
+					}
+					else
+					{
+						SetEntPropFloat(this.iClient, Prop_Send, "m_flItemChargeMeter", data.flWeaponChargeMeter[i], i);
+					}
+				}
+				
+				case TFWeaponSlot_Melee:
+				{
+					if (StrEqual(sClassname, "tf_weapon_knife"))
+					{
+						// ??????? i don't fuckin know lol
+						if ((data.flLastSwitch - data.flWeaponChargeTime[i]) < 15.0)
+						{
+							SetEntPropFloat(iWeapon, Prop_Send, "m_flKnifeMeltTimestamp", GetGameTime());
+							SetEntPropFloat(iWeapon, Prop_Send, "m_flKnifeRegenerateDuration", 15.0 - (data.flLastSwitch - data.flWeaponChargeTime[i]));
+							
+							data.flWeaponChargeTime[i] = GetGameTime();
+						}
+						else
+						{
+							data.flWeaponChargeTime[i] = GetGameTime() - 15.0;
+						}
+					}
+					else if (HasEntProp(iWeapon, Prop_Send, "m_flEffectBarRegenTime"))
+					{
+						SetEntPropFloat(iWeapon, Prop_Send, "m_flEffectBarRegenTime", (data.flWeaponChargeTime[i] + GetGameTime()) - data.flLastSwitch);
+					}
+					else
+					{
+						if (data.flWeaponChargeMeter[i] > 0.0)
+							SetEntPropFloat(this.iClient, Prop_Send, "m_flItemChargeMeter", data.flWeaponChargeMeter[i], i);
+					}
+				}
+			}
+		}
+	}
+	
+	public void ResetAllClassData()
+	{
+		if (!g_aClassData[this.iClient])
+		{
+			g_aClassData[this.iClient] = new ArrayList(sizeof(ClassData));
+		}
+		else
+		{
+			g_aClassData[this.iClient].Clear();
+		}
 	}
 	
 	public bool IsInCooldown(bool bDisplayText = false)
@@ -218,5 +508,22 @@ methodmap Player
 			return true;
 		
 		return false;
+	}
+	
+	public void Destroy()
+	{
+		// Free up memory space
+		delete g_aClassData[this.iClient];
+		
+		// Destroy all buildings
+		int iBuilding = MaxClients + 1;
+		while ((iBuilding = FindEntityByClassname(iBuilding, "obj_*")) > MaxClients)
+		{
+			if (IsValidEntity(iBuilding) && GetEntPropEnt(iBuilding, Prop_Send, "m_hBuilder") == this.iClient)
+			{
+				SetVariantInt(999999);
+				AcceptEntityInput(iBuilding, "RemoveHealth");
+			}
+		}
 	}
 }

--- a/scripting/ccotg/methodmaps.sp
+++ b/scripting/ccotg/methodmaps.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 static float g_flLastClassChange[MAXPLAYERS + 1];
 static bool g_bHasChangedClass[MAXPLAYERS + 1];
 static bool g_bIsInRespawnRoom[MAXPLAYERS + 1];

--- a/scripting/ccotg/sdkcalls.sp
+++ b/scripting/ccotg/sdkcalls.sp
@@ -1,6 +1,9 @@
 static Handle g_hSDKCallGetMaxHealth;
 static Handle g_hSDKCallAddObject;
 static Handle g_hSDKCallRemoveObject;
+static Handle g_hSDKCallGetEquippedWearableForLoadoutSlot;
+static Handle g_hSDKCallGetMaxClip;
+static Handle g_hSDKCallGetMaxAmmo;
 
 void SDKCall_Init()
 {
@@ -8,7 +11,7 @@ void SDKCall_Init()
 	if (hGameData == null)
 		SetFailState("Could not find sdkhooks.games gamedata!"); 
 
-	// This function is used to retrieve a player's max health
+	// This call is used to retrieve a player's max health
 	StartPrepSDKCall(SDKCall_Player);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "GetMaxHealth");
 	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
@@ -29,7 +32,7 @@ void SDKCall_Init()
 	g_hSDKCallAddObject = EndPrepSDKCall();
 	if (g_hSDKCallAddObject == null)
 		LogMessage("Failed to create call: CTFPlayer::AddObject!");
-
+	
 	// This call is used to remove a building's owner
 	StartPrepSDKCall(SDKCall_Player);
 	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::RemoveObject");
@@ -37,7 +40,34 @@ void SDKCall_Init()
 	g_hSDKCallRemoveObject = EndPrepSDKCall();
 	if (g_hSDKCallRemoveObject == null)
 		LogMessage("Failed to create call: CTFPlayer::RemoveObject!");
-		
+	
+	// This call is used to correctly get wearables from a loadout slot
+	StartPrepSDKCall(SDKCall_Player);
+	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::GetEquippedWearableForLoadoutSlot");
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_SetReturnInfo(SDKType_CBaseEntity, SDKPass_Pointer);
+	g_hSDKCallGetEquippedWearableForLoadoutSlot = EndPrepSDKCall();
+	if (g_hSDKCallGetEquippedWearableForLoadoutSlot == null)
+		LogMessage("Failed to create call: CTFPlayer::GetEquippedWearableForLoadoutSlot");
+	
+	// This call is used to get the maximum clip 1 for a given weapon
+	StartPrepSDKCall(SDKCall_Entity);
+	PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, "CTFWeaponBase::GetMaxClip1");
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+	g_hSDKCallGetMaxClip = EndPrepSDKCall();
+	if (g_hSDKCallGetMaxClip == null)
+		LogMessage("Failed to create call: CTFWeaponBase::GetMaxClip1!");
+	
+	// This call is used to get a weapon's max ammo
+	StartPrepSDKCall(SDKCall_Player);
+	PrepSDKCall_SetFromConf(hGameData, SDKConf_Signature, "CTFPlayer::GetMaxAmmo");
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+	g_hSDKCallGetMaxAmmo = EndPrepSDKCall();
+	if (g_hSDKCallGetMaxAmmo == null)
+		LogMessage("Failed to create call: CTFPlayer::GetMaxAmmo!");
+	
 	delete hGameData;
 }
 
@@ -59,4 +89,28 @@ void SDKCall_RemoveObject(int iClient, int iEntity)
 {
 	if (g_hSDKCallRemoveObject != null)
 		SDKCall(g_hSDKCallRemoveObject, iClient, iEntity);
+}
+
+int SDKCall_GetEquippedWearableForLoadoutSlot(int iClient, int iSlot)
+{
+	if (g_hSDKCallGetEquippedWearableForLoadoutSlot != null)
+		return SDKCall(g_hSDKCallGetEquippedWearableForLoadoutSlot, iClient, iSlot);
+	
+	return -1;
+}
+
+int SDKCall_GetMaxClip(int iWeapon)
+{
+	if (g_hSDKCallGetMaxClip != null)
+		return SDKCall(g_hSDKCallGetMaxClip, iWeapon);
+	
+	return -1;
+}
+
+int SDKCall_GetMaxAmmo(int iClient, int iSlot)
+{
+	if (g_hSDKCallGetMaxAmmo != null)
+		return SDKCall(g_hSDKCallGetMaxAmmo, iClient, iSlot, -1);
+	
+	return -1;
 }

--- a/scripting/ccotg/sdkcalls.sp
+++ b/scripting/ccotg/sdkcalls.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 static Handle g_hSDKCallGetMaxHealth;
 static Handle g_hSDKCallAddObject;
 static Handle g_hSDKCallRemoveObject;

--- a/scripting/ccotg/sdkhooks.sp
+++ b/scripting/ccotg/sdkhooks.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 public Action SDKHook_FuncRespawnRoom_StartTouch(int iEntity, int iClient)
 {
 	if (g_bArenaMode)

--- a/scripting/ccotg/stocks.sp
+++ b/scripting/ccotg/stocks.sp
@@ -1,3 +1,13 @@
+stock any Min(any a, any b)
+{
+	return (a <= b) ? a : b;
+}
+
+stock any Max(any a, any b)
+{
+	return (a >= b) ? a : b;
+}
+
 stock bool IsValidClient(int iClient)
 {
 	return 0 < iClient <= MaxClients && IsClientInGame(iClient);
@@ -20,6 +30,21 @@ stock void PrintKeyHintText(int iClient, const char[] sFormat, any...)
 	bf.WriteByte(1);	//One message
 	bf.WriteString(sBuffer);
 	EndMessage();
+}
+
+stock int TF2_GetItemInSlot(int iClient, int iSlot)
+{
+	int iWeapon = GetPlayerWeaponSlot(iClient, iSlot);
+	if (!IsValidEdict(iWeapon))
+	{
+		// If a weapon was not found in slot, check if it's a wearable
+		int iWearable = SDKCall_GetEquippedWearableForLoadoutSlot(iClient, iSlot);
+		
+		if (IsValidEdict(iWearable))
+			iWeapon = iWearable;
+	}
+	
+	return iWeapon;
 }
 
 stock int ShowParticle(char[] sParticle, float flDuration, float vecPos[3], float vecAngles[3] = NULL_VECTOR)

--- a/scripting/ccotg/stocks.sp
+++ b/scripting/ccotg/stocks.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 stock any Min(any a, any b)
 {
 	return (a <= b) ? a : b;


### PR DESCRIPTION
Changes:
- Added `ccotg_ammo_management`, which keeps track of how much ammo and similar things each class had before switching off. Resets when the player respawns.
- Fixed buildings staying on the map after a player disconnects.