### PR TITLE
0.4 - General changes/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Scuffed pseudo-gamemode that allows everyone to change classes at will, anywhere
 |`ccotg_ammo_management`|1|Saves ammo, charge meters, heads and similar things separately for each class until death.|
 
 ## Thanks To
-* [42](https://github.com/FortyTwoFortyTwo), [Mikusch](https://github.com/Mikusch) & [Red Sun Over Paradise](https://redsun.tf) for helping me out with public playtesting and feedback.
+* [42](https://github.com/FortyTwoFortyTwo), [Mikusch](https://github.com/Mikusch) & [Red Sun Over Paradise](https://redsun.tf) for helping me out with public playtesting and providing feedback.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ Scuffed pseudo-gamemode that allows everyone to change classes at will, anywhere
 |`ccotg_health_mode`|1|How should health be handled upon changing classes?<br>- 1: Don't change health<br>- 2: Keep the ratio of health to max health the same<br>- Any other value: Full heal|
 |`ccotg_health_max_overheal`|1.5|Max amount of overheal (multiplier of max health) that players are allowed to keep upon changing classes.|
 |`ccotg_ammo_management`|1|Saves ammo, charge meters, heads and similar things separately for each class until death.|
+
+## Thanks To
+* [42](https://github.com/FortyTwoFortyTwo), [Mikusch](https://github.com/Mikusch) & [Red Sun Over Paradise](https://redsun.tf) for helping me out with public playtesting and feedback.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Scuffed pseudo-gamemode that allows everyone to change classes at will, anywhere
 ## ConVars
 - `ccotg_enabled` (1) - Is 'Change Class on the Go' enabled?
 - `ccotg_cooldown` (0.0) - Amount of time (in seconds!) required for a player to be allowed to change classes again.
+- `ccotg_particle` (1) - Adds a team-coloured particle effect for switching classes.
 - `ccotg_only_allow_team` ("") - Only allows the specified team to make use of this plugin's functionality. Accepts 'red' and 'blu(e)', anything else means we'll assume you're fine with both teams.
 - `ccotg_keep_buildings` (1) - Lets buildings stay on the map if a player switches from Engineer. Disabling makes them get destroyed instead.
 - `ccotg_keep_momentum` (1) - Players keep momentum after switching classes.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Scuffed pseudo-gamemode that allows everyone to change classes at will, anywhere
 - `ccotg_cooldown` (0.0) - Amount of time (in seconds!) required for a player to be allowed to change classes again.
 - `ccotg_only_allow_team` ("") - Only allows the specified team to make use of this plugin's functionality. Accepts 'red' and 'blu(e)', anything else means we'll assume you're fine with both teams.
 - `ccotg_keep_buildings` (1) - Lets buildings stay on the map if a player switches from Engineer. Disabling makes them get destroyed instead.
+- `ccotg_keep_momentum` (1) - Players keep momentum after switching classes.
 - `ccotg_prevent_switching_during_bad_states` (1) - Lazy temporary beta convar - disallows switching classes if players are doing the following: Jetpacking (to prevent a persistent looping sound bug) and hauling a building (does some bad animation stuff).
 - `ccotg_arena_change_round_states` (1) - Pretend to change the round state in arena mode so players can use the default 'changeclass' key mid round. Visually, slightly breaks the central Control Point! Disabling will let players change classes with their 'dropitem' key as a fallback instead.
 - `ccotg_health_mode` (1) - How should health be handled upon changing classes?

--- a/README.md
+++ b/README.md
@@ -7,17 +7,16 @@ Scuffed pseudo-gamemode that allows everyone to change classes at will, anywhere
 - [More Colors](https://forums.alliedmods.net/showthread.php?t=185016) (compile only)
 
 ## ConVars
-- `ccotg_enabled` (1) - Is 'Change Class on the Go' enabled?
-- `ccotg_cooldown` (0.0) - Amount of time (in seconds!) required for a player to be allowed to change classes again.
-- `ccotg_particle` (1) - Adds a team-coloured particle effect for switching classes.
-- `ccotg_only_allow_team` ("") - Only allows the specified team to make use of this plugin's functionality. Accepts 'red' and 'blu(e)', anything else means we'll assume you're fine with both teams.
-- `ccotg_keep_buildings` (1) - Lets buildings stay on the map if a player switches from Engineer. Disabling makes them get destroyed instead.
-- `ccotg_keep_momentum` (1) - Players keep momentum after switching classes.
-- `ccotg_prevent_switching_during_bad_states` (1) - Lazy temporary beta convar - disallows switching classes if players are doing the following: Jetpacking (to prevent a persistent looping sound bug) and hauling a building (does some bad animation stuff).
-- `ccotg_arena_change_round_states` (1) - Pretend to change the round state in arena mode so players can use the default 'changeclass' key mid round. Visually, slightly breaks the central Control Point! Disabling will let players change classes with their 'dropitem' key as a fallback instead.
-- `ccotg_health_mode` (1) - How should health be handled upon changing classes?
-	- 1: Don't change health
-	- 2: Keep the ratio of health to max health the same
-	- Any other value: Full heal
-- `ccotg_health_max_overheal` (1.5) - Max amount of overheal (multiplier of max health) that players are allowed to keep upon changing classes.
-- `ccotg_ammo_management` (1) - Saves ammo, charge meters, heads and similar things separately for each class until death.
+|ConVar|Default Value|Description|
+|-|:-:|-|
+|`ccotg_enabled`|1|Is 'Change Class on the Go' enabled?|
+|`ccotg_cooldown`|0.0|Amount of time (in seconds!) required for a player to be allowed to change classes again.|
+|`ccotg_particle`|1|Adds a team-coloured particle effect for switching classes.|
+|`ccotg_only_allow_team`|""|Only allows the specified team to make use of this plugin's functionality.<br>Accepts 'red' and 'blu(e)', anything else means we'll assume you're fine with both teams.|
+|`ccotg_keep_buildings`|1|Lets buildings stay on the map if a player switches from Engineer.<br>Disabling makes them get destroyed instead.|
+|`ccotg_keep_momentum`|1|Players keep momentum after switching classes.|
+|`ccotg_restrict_broken_conditions`|1|Disallows switching classes if players are jetpacking (to prevent a persistent looping sound bug) or hauling a building (does some bad animation stuff).|
+|`ccotg_arena_change_round_states`|1|Pretends to change the round state in arena mode so players can use the default 'changeclass' key mid round.<br>Visually, slightly breaks the central Control Point!<br>Disabling will let players change classes with their 'dropitem' key as a fallback instead.|
+|`ccotg_health_mode`|1|How should health be handled upon changing classes?<br>- 1: Don't change health<br>- 2: Keep the ratio of health to max health the same<br>- Any other value: Full heal|
+|`ccotg_health_max_overheal`|1.5|Max amount of overheal (multiplier of max health) that players are allowed to keep upon changing classes.|
+|`ccotg_ammo_management`|1|Saves ammo, charge meters, heads and similar things separately for each class until death.|

--- a/scripting/ccotg.sp
+++ b/scripting/ccotg.sp
@@ -9,7 +9,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION		"0.3"
+#define PLUGIN_VERSION	"0.3"
 
 bool g_bArenaMode;
 
@@ -290,4 +290,3 @@ public Action SendProxy_ArenaRoundState(const char[] sPropName, int &iValue, int
 	
 	return Plugin_Continue;
 }
-	

--- a/scripting/ccotg.sp
+++ b/scripting/ccotg.sp
@@ -48,6 +48,7 @@ ConVar g_cvEnabled;
 ConVar g_cvCooldown;
 ConVar g_cvOnlyAllowTeam;
 ConVar g_cvKeepBuildings;
+ConVar g_cvKeepMomentum;
 ConVar g_cvHealthMode;
 ConVar g_cvHealthMaxOverheal;
 ConVar g_cvAmmoManagement;

--- a/scripting/ccotg.sp
+++ b/scripting/ccotg.sp
@@ -9,7 +9,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION	"0.3"
+#define PLUGIN_VERSION	"0.4"
 
 bool g_bArenaMode;
 
@@ -176,6 +176,7 @@ public void Disable()
 		if (IsClientInGame(iClient))
 			OnClientDisconnect(iClient);
 	}
+	
 	int iEntity = MaxClients + 1;
 	
 	// Unhook spawn rooms

--- a/scripting/ccotg.sp
+++ b/scripting/ccotg.sp
@@ -46,6 +46,7 @@ enum
 
 ConVar g_cvEnabled;
 ConVar g_cvCooldown;
+ConVar g_cvParticle;
 ConVar g_cvOnlyAllowTeam;
 ConVar g_cvKeepBuildings;
 ConVar g_cvKeepMomentum;

--- a/scripting/ccotg/console.sp
+++ b/scripting/ccotg/console.sp
@@ -19,7 +19,7 @@ public Action CommandListener_ChangeClass(int iClient, const char[] sCommand, in
 	if (!IsValidClient(iClient) || !IsPlayerAlive(iClient))
 		return Plugin_Continue;
 	
-	// This is the fallback in case the convar for messing with round states is disabled. Players will need to press the dropitem keybind to change classes instead	
+	// This is the fallback in case the convar for messing with round states is disabled. Players will need to press the dropitem keybind to change classes instead
 	char sVGUIMenu[16];
 	TFTeam nTeam = TF2_GetClientTeam(iClient);
 	
@@ -36,7 +36,7 @@ public Action CommandListener_ChangeClass(int iClient, const char[] sCommand, in
 	
 	return Plugin_Continue;
 }
-	
+
 public Action CommandListener_JoinClass(int iClient, const char[] sCommand, int iArgs)
 {
 	if (!g_cvEnabled.BoolValue)
@@ -45,7 +45,7 @@ public Action CommandListener_JoinClass(int iClient, const char[] sCommand, int 
 	if (!IsValidClient(iClient) || !IsPlayerAlive(iClient))
 		return Plugin_Continue;
 	
-	if ((Player(iClient).bIsInRespawnRoom && !g_cvAmmoManagement.BoolValue) || GameRules_GetRoundState() == RoundState_Preround)
+	if ((Player(iClient).bIsInRespawnRoom && g_cvAmmoManagement.BoolValue) || GameRules_GetRoundState() == RoundState_Preround)
 		return Plugin_Continue;
 	
 	if (!Player(iClient).CanTeamChangeClass())
@@ -78,7 +78,7 @@ public Action CommandListener_JoinClass(int iClient, const char[] sCommand, int 
 		
 		while (nRandomClass == nCurrentClass)
 			nRandomClass = view_as<TFClassType>(GetRandomInt(view_as<int>(TFClass_Scout), view_as<int>(TFClass_Engineer)));
-			
+		
 		strcopy(sClass, sizeof(sClass), g_sClassNames[view_as<int>(nRandomClass)]);
 	}
 	
@@ -89,7 +89,7 @@ public Action CommandListener_JoinClass(int iClient, const char[] sCommand, int 
 	if (Player(iClient).IsInCooldown(!bSameClass))
 	{
 		Player(iClient).nBufferedClass = nNewClass;
-			
+		
 		g_hBufferTimer[iClient] = CreateTimer(0.1, Timer_DealWithBuffer, iClient);
 		return Plugin_Handled;
 	}

--- a/scripting/ccotg/console.sp
+++ b/scripting/ccotg/console.sp
@@ -45,7 +45,7 @@ public Action CommandListener_JoinClass(int iClient, const char[] sCommand, int 
 	if (!IsValidClient(iClient) || !IsPlayerAlive(iClient))
 		return Plugin_Continue;
 	
-	if (Player(iClient).bIsInRespawnRoom || GameRules_GetRoundState() == RoundState_Preround)
+	if ((Player(iClient).bIsInRespawnRoom && !g_cvAmmoManagement.BoolValue) || GameRules_GetRoundState() == RoundState_Preround)
 		return Plugin_Continue;
 	
 	if (!Player(iClient).CanTeamChangeClass())

--- a/scripting/ccotg/convars.sp
+++ b/scripting/ccotg/convars.sp
@@ -6,6 +6,7 @@ void ConVar_Init()
 	g_cvEnabled = CreateConVar("ccotg_enabled", "1", "Is 'Change Class on the Go' enabled?", _, true, 0.0, true, 1.0);
 	g_cvEnabled.AddChangeHook(ConVar_EnabledChanged);
 	g_cvCooldown = CreateConVar("ccotg_cooldown", "0.0", "Amount of time (in seconds!) required for a player to be allowed to change classes again.");
+	g_cvParticle = CreateConVar("ccotg_particle", "1", "Adds a team-coloured particle effect for switching classes.");
 	g_cvOnlyAllowTeam = CreateConVar("ccotg_only_allow_team", "", "Only allows the specified team to make use of this plugin's functionality. Accepts 'red' and 'blu(e)', anything else means we'll assume you're fine with both teams.");
 	g_cvOnlyAllowTeam.AddChangeHook(ConVar_OnlyAllowTeamChanged);
 	g_cvKeepBuildings = CreateConVar("ccotg_keep_buildings", "1", "Lets buildings stay on the map if a player switches from Engineer. Disabling makes them get destroyed instead.");

--- a/scripting/ccotg/convars.sp
+++ b/scripting/ccotg/convars.sp
@@ -9,6 +9,7 @@ void ConVar_Init()
 	g_cvOnlyAllowTeam = CreateConVar("ccotg_only_allow_team", "", "Only allows the specified team to make use of this plugin's functionality. Accepts 'red' and 'blu(e)', anything else means we'll assume you're fine with both teams.");
 	g_cvOnlyAllowTeam.AddChangeHook(ConVar_OnlyAllowTeamChanged);
 	g_cvKeepBuildings = CreateConVar("ccotg_keep_buildings", "1", "Lets buildings stay on the map if a player switches from Engineer. Disabling makes them get destroyed instead.");
+	g_cvKeepMomentum = CreateConVar("ccotg_keep_momentum", "1", "Players keep momentum after switching classes.");
 	g_cvHealthMode = CreateConVar("ccotg_health_mode", "1", "How should health be handled upon changing classes?\n1: Don't change health\n2: Keep the ratio of health to max health the same\nAny other value: Full heal");
 	g_cvHealthMaxOverheal = CreateConVar("ccotg_health_max_overheal", "1.5", "Max amount of overheal (multiplier of max health) that players are allowed to keep upon changing classes.");
 	g_cvAmmoManagement = CreateConVar("ccotg_ammo_management", "1", "Saves ammo, charge meters, heads and similar things separately for each class until death.");

--- a/scripting/ccotg/convars.sp
+++ b/scripting/ccotg/convars.sp
@@ -14,7 +14,7 @@ void ConVar_Init()
 	g_cvHealthMode = CreateConVar("ccotg_health_mode", "1", "How should health be handled upon changing classes?\n1: Don't change health\n2: Keep the ratio of health to max health the same\nAny other value: Full heal");
 	g_cvHealthMaxOverheal = CreateConVar("ccotg_health_max_overheal", "1.5", "Max amount of overheal (multiplier of max health) that players are allowed to keep upon changing classes.");
 	g_cvAmmoManagement = CreateConVar("ccotg_ammo_management", "1", "Saves ammo, charge meters, heads and similar things separately for each class until death.");
-	g_cvPreventSwitchingDuringBadStates = CreateConVar("ccotg_prevent_switching_during_bad_states", "1", "Lazy temporary beta convar - disallows switching classes if are doing following: Jetpacking (to prevent a persistent looping sound bug) and hauling a building (does some bad animation stuff)");
+	g_cvPreventSwitchingDuringBadStates = CreateConVar("ccotg_restrict_broken_conditions", "1", "Disallows switching classes if players are jetpacking (to prevent a persistent looping sound bug) or hauling a building (does some bad animation stuff)");
 	g_cvMessWithArenaRoundStates = CreateConVar("ccotg_arena_change_round_states", "1", "Pretend to change the round state in arena mode so players can use the default 'changeclass' key mid round. Visually, slightly breaks the central Control Point! Disabling will let players change classes with their 'dropitem' key as a fallback instead.");
 	g_cvMessWithArenaRoundStates.AddChangeHook(ConVar_MessWithArenaRoundStatesChanged);
 }

--- a/scripting/ccotg/methodmaps.sp
+++ b/scripting/ccotg/methodmaps.sp
@@ -501,7 +501,7 @@ methodmap Player
 			return bResult;
 		
 		// TFCond_RocketPack makes the looping woosh sound persist until you switch back to Pyro (or die)
-		if (TF2_IsPlayerInCondition(this.iClient, TFCond_RocketPack))
+		if (TF2_IsPlayerInCondition(this.iClient, TFCond_RocketPack) && TF2_GetPlayerClass(this.iClient) == TFClass_Pyro)
 		{
 			if (bDisplayText)
 				CPrintToChat(this.iClient, "%t", "ChangeClass_Wait_BadState_Jetpacking");

--- a/scripting/ccotg/methodmaps.sp
+++ b/scripting/ccotg/methodmaps.sp
@@ -199,10 +199,13 @@ methodmap Player
 		if (!g_cvKeepMomentum.BoolValue)
 			TeleportEntity(this.iClient, NULL_VECTOR, NULL_VECTOR, {0.0, 0.0, 0.0});
 		
-		// Add a little effect
-		float vecPos[3];
-		GetClientAbsOrigin(this.iClient, vecPos);
-		ShowParticle(TF2_GetClientTeam(this.iClient) == TFTeam_Blue ? "teleportedin_blue" : "teleportedin_red", 0.1, vecPos);
+		// Add a little effect, if set
+		if (g_cvParticle.BoolValue)
+		{
+			float vecPos[3];
+			GetClientAbsOrigin(this.iClient, vecPos);
+			ShowParticle(TF2_GetClientTeam(this.iClient) == TFTeam_Blue ? "teleportedin_blue" : "teleportedin_red", 0.1, vecPos);
+		}
 		
 		// Update properties
 		this.flLastClassChange = GetGameTime();

--- a/scripting/ccotg/methodmaps.sp
+++ b/scripting/ccotg/methodmaps.sp
@@ -195,6 +195,10 @@ methodmap Player
 		// Set final health
 		SetEntProp(this.iClient, Prop_Send, "m_iHealth", iFinalHealth);
 		
+		// Remove momentum, if the convar is disabled
+		if (!g_cvKeepMomentum.BoolValue)
+			TeleportEntity(this.iClient, NULL_VECTOR, NULL_VECTOR, {0.0, 0.0, 0.0});
+		
 		// Add a little effect
 		float vecPos[3];
 		GetClientAbsOrigin(this.iClient, vecPos);

--- a/scripting/ccotg/methodmaps.sp
+++ b/scripting/ccotg/methodmaps.sp
@@ -390,7 +390,7 @@ methodmap Player
 				{
 					if (StrEqual(sClassname, "tf_weapon_particle_cannon") || StrEqual(sClassname, "tf_weapon_drg_pomson"))
 					{
-						SetEntPropFloat(iWeapon, Prop_Send, "m_flEnergy", data.flWeaponChargeMeter[i]);
+						SetEntPropFloat(iWeapon, Prop_Send, "m_flEnergy", Min(data.flWeaponChargeMeter[i], 20.0));
 					}
 					else
 					{
@@ -408,7 +408,7 @@ methodmap Player
 					}
 					else if (StrEqual(sClassname, "tf_weapon_raygun"))
 					{
-						SetEntPropFloat(iWeapon, Prop_Send, "m_flEnergy", data.flWeaponChargeMeter[i]);
+						SetEntPropFloat(iWeapon, Prop_Send, "m_flEnergy", Min(data.flWeaponChargeMeter[i], 20.0));
 					}
 					else if (StrEqual(sClassname, "tf_weapon_charged_smg"))
 					{
@@ -421,7 +421,8 @@ methodmap Player
 					}
 					else
 					{
-						SetEntPropFloat(this.iClient, Prop_Send, "m_flItemChargeMeter", data.flWeaponChargeMeter[i], i);
+						if (data.flWeaponChargeMeter[i] > 0.0)
+							SetEntPropFloat(this.iClient, Prop_Send, "m_flItemChargeMeter", data.flWeaponChargeMeter[i], i);
 					}
 				}
 				


### PR DESCRIPTION
Cleanup crew. Changes:
- Added `ccotg_keep_momentum` (enabled by default), removes the player's momentum upon switching classes if disabled
- Added `ccotg_particle` (enabled by default), handles the particle effect that was already present upon switching classes
- Renamed `ccotg_prevent_switching_during_bad_states` to `ccotg_restrict_broken_conditions`, functionality is the same
- The plugin will now handle class switching in spawn if ammo management is enabled
- Fixed ammo management assuming energy weapons have a maximum of 100.0 energy, instead of 20.0
- Fixed Quick-Fix Medics who jetpack alongside a Pyro by healing them being permanently stuck in a "bad switching state"